### PR TITLE
Support for <let> and document() in XPath selectors, PHP 8.2 deprecation fixes, and GitHub Actions integration

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,43 @@
+name: validate and test
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        php-versions: ['8.0', '8.1' , '8.2' , '8.3']
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: libxml, xml, dom
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --no-interaction  --dev
+    
+    # -C to make sure dom extension is loaded
+    - name: Run test suite
+      run: php vendor/bin/tester -C -s tests

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,12 @@
 		"ext-dom": "*"
 	},
 	"require-dev": {
-		"nette/tester": "~1.1.0"
+		"nette/tester": "^2.5"
 	},
 	"autoload": {
 		"classmap": ["src/Schematron.php"]
-	}
+	},
+	"scripts": {
+        "test": "vendor/bin/tester -s tests"
+    }
 }

--- a/src/Schematron.php
+++ b/src/Schematron.php
@@ -163,6 +163,9 @@ class Schematron
 	/** @var array[id => value]  {@see self::findPhases()} */
 	protected $phases = array();
 
+    /* var array list of opened external DOMDOCUMENT and Xpath (to support document() in xpath ) */
+    protected $externals = [];
+
 
 
 
@@ -279,9 +282,47 @@ class Schematron
 			$pattern = $this->patterns[$patternKey];
 			foreach ($pattern->rules as $ruleKey => $rule) {
 				foreach ($xpath->queryContext($rule->context, $doc) as $currentNode) {
+                    $lets = [];
+                    if ($rule->lets) {
+                        foreach ($rule->lets as $name => $value) {
+                            $let = $xpath->evaluate("string($value)", $currentNode);
+                            // Adding quotes is necessary to be able search strings
+							// TODO : maybe escape?
+							$lets[$name] = is_numeric($let) ? $let : "'$let'";
+                        }
+                    }
 					foreach ($rule->statements as $statement) {
-						if ($statement->isAssert ^ $xpath->evaluate("boolean($statement->test)", $currentNode)) {
-							$message = $this->statementToMessage($statement->node, $xpath, $currentNode);
+                        $testStatement = $statement->test ;
+                        $nodeToEval = $currentNode;
+                        $xpathToEval = $xpath;
+                        if ($lets) {
+                            $testStatement = call_user_func($this->getReplaceCb(), $testStatement, $lets);
+                        }
+                        // Added support to evaluate document()
+						// Maybe it should move to SchematronXPath, but we would have to deal with paths 
+						// as neither DOMDocument or XPATH holds information about the file, so is it really worth the trouble?
+                        $parts = explode('//', $testStatement);
+                        if (count($parts) == 2) {
+                            if ($parts[0]) {
+                                if (strpos($parts[0], 'document(') == 0) {
+                                    $file = substr($parts[0], 10, -2);
+                                    if (!isset($this->externals[$file])) {
+                                        $external = new DOMDocument();
+                                        $external->load($this->directory.DIRECTORY_SEPARATOR.$file);
+                                        $this->externals[$file] = [
+                                            'node' => $external,
+                                            'xpath' => new DOMXPath($external)
+                                        ];
+                                    }
+                                    $nodeToEval = $this->externals[$file]['node'];
+                                    $xpathToEval = $this->externals[$file]['xpath'];
+                                    $testStatement = "//".$parts[1];
+                                }
+                            }
+
+                        }
+						if ($statement->isAssert ^ $xpathToEval->evaluate("boolean($testStatement)", $nodeToEval)) {
+							$message = $this->statementToMessage($statement->node, $xpath, $currentNode, $lets);
 
 							switch ($result) {
 								case self::RESULT_EXCEPTION:
@@ -739,6 +780,7 @@ class Schematron
 
 			$rules[] = (object) array(
 				'context' => $context,
+                'lets' => $this->findLets($element),
 				'statements' => $statements = $this->findStatements($element, $abstracts),
 			);
 
@@ -848,13 +890,28 @@ class Schematron
 		return $actives;
 	}
 
+    /**
+     * Search for all <sch:let>.
+     * @return array
+     */
+    protected function findLets(DOMElement $rule)
+    {
+        $variables = array();
+        foreach ($this->xPath->query('sch:let', $rule) as $node) {
+            $name = Helpers::getAttribute($node, 'name');
+            $value = Helpers::getAttribute($node, 'value');
+            $variables[$name] = $value;
+        }
+        return $variables;
+    }
+
 
 
 	/**
 	 * Expands <sch:name> and <sch:value-of> in assertion/report message.
 	 * @return string
 	 */
-	protected function statementToMessage(DOMElement $stmt, SchematronXPath $xPath, DOMNode $current)
+	protected function statementToMessage(DOMElement $stmt, SchematronXPath $xPath, DOMNode $current, $lets = array())
 	{
 		$message = '';
 		foreach ($stmt->childNodes as $node) {
@@ -863,7 +920,11 @@ class Schematron
 					$message .= $xPath->evaluate('name(' . Helpers::getAttribute($node, 'path', '') . ')', $current);
 
 				} elseif ($node->localName === 'value-of') {
-					$message .= $xPath->evaluate('string(' . Helpers::getAttribute($node, 'select') . ')', $current);
+                    $selected =  Helpers::getAttribute($node, 'select');
+                    if ($lets){
+						$selected = call_user_func($this->getReplaceCb(),$selected, $lets) ;
+					}
+					$message .= $xPath->evaluate('string(' . $selected . ')', $current);
 
 				} else {
 					/** @todo warning? */
@@ -1015,7 +1076,7 @@ class SchematronXPath extends DOMXPath
 
 
 
-	public function queryContext($expression, DOMNode $context = NULL, $registerNodeNS = FALSE)
+	public function queryContext($expression, DOMNode $context = NULL, $registerNodeNS = FALSE): mixed
 	{
 		if (isset($expression[0]) && $expression[0] !== '.' && $expression[0] !== '/') {
 			$expression = "//$expression";

--- a/src/Schematron.php
+++ b/src/Schematron.php
@@ -7,7 +7,6 @@ use Milo\SchematronHelpers as Helpers;
 use DOMDocument,
 	DOMElement,
 	DOMNode,
-	DOMNodeList,
 	DOMXPath;
 
 use ErrorException,
@@ -999,7 +998,7 @@ class SchematronXPath extends DOMXPath
 	/**
 	 * ($registerNodeNS is FALSE in opposition to DOMXPath default value)
 	 */
-	public function query($expression, DOMNode $context = NULL, $registerNodeNS = FALSE)
+	public function query($expression, DOMNode $context = NULL, $registerNodeNS = FALSE): mixed
 	{
 		return parent::query($expression, $context, $registerNodeNS);
 	}
@@ -1009,7 +1008,7 @@ class SchematronXPath extends DOMXPath
 	/**
 	 * ($registerNodeNS is FALSE in opposition to DOMXPath default value)
 	 */
-	public function evaluate($expression, DOMNode $context = NULL, $registerNodeNS = FALSE)
+	public function evaluate($expression, DOMNode $context = NULL, $registerNodeNS = FALSE): mixed
 	{
 		return parent::evaluate($expression, $context, $registerNodeNS);
 	}

--- a/tests/Schematron.validate.phpt
+++ b/tests/Schematron.validate.phpt
@@ -40,16 +40,19 @@ $simple = array(
 	'S13 - fail - milo',
 	'S14 - fail - name',
 	'S15 - fail',
+	'S17 - fail',
+	'S19 - fail',
 );
 Assert::same($simple, $sch->validate($doc));
 
 
 # RESULT_COMPLEX
 $complex = $sch->validate($doc, $sch::RESULT_COMPLEX);
-Assert::same(count($complex), 3);
+Assert::same(count($complex), 4);
 Assert::true(isset($complex['#p1']->rules[0]->errors[0]->message));
 Assert::same($complex['#p1']->rules[0]->errors[0]->message, 'S15 - fail');
 Assert::same(reset($complex)->title, 'Pattern 1');
+Assert::true(isset($complex['#let']->rules[0]->errors[0]->message));
 
 
 # RESULT_EXCEPTION

--- a/tests/resources/external-document.xml
+++ b/tests/resources/external-document.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <names>
+    <name value="milo"/>
+    <name value="rahal"/>
+  </names>
+</root>

--- a/tests/resources/validate-schema.xml
+++ b/tests/resources/validate-schema.xml
@@ -67,4 +67,15 @@
 		</rule>
 	</pattern>
 
+	<pattern id="let">
+		<rule context="root">
+			<let name="milo" value="//person/name"/>
+			<assert test="//person/name = $milo">S16 - pass</assert>
+			<let name="nick" value="//a:nickname"/>
+			<assert test="//person/name = $nick">S17 - fail</assert>
+			<assert test="document('external-document.xml')//names/name[@value=$nick]">S18 - pass</assert>
+			<assert test="document('external-document.xml')//names/name[@value=$milo]">S19 - fail</assert>
+		</rule>
+	</pattern>
+
 </schema>


### PR DESCRIPTION
Thank you for your great work on milo/schematron. As the maintainer of youniwemi/digital-invoice, I needed a lightweight library for schematron validation. Your library nearly met my needs perfectly, but I found that support for <let> and the document() function in xpath selectors was lacking.

To address this, I added these features and updated the test cases. Additionally, I included fixes for some PHP 8.2 deprecations and set up a GitHub action to test across PHP versions 8.0 to 8.3 (that's why I had to update nette/tester version).

I welcome any feedback on this PR. Thank you for considering those changes.

Best regards,
rahal